### PR TITLE
Align cache timing with detected cron interval

### DIFF
--- a/website-beta/public/scripts/partial-update.js
+++ b/website-beta/public/scripts/partial-update.js
@@ -7,7 +7,7 @@
   if (!app) return;
 
   let lastUpdated = Number(app.dataset.lastUpdated || 0);
-  const cacheMinutes = Number(app.dataset.cacheMinutes || 1);
+  const cacheMinutes = Number(app.dataset.cacheMinutes || 3);
   let nextGenTs = Number(app.dataset.nextGenTs || 0) || null;
 
   const metaUrl = "/v1/api/status/meta";

--- a/website-beta/src/index.tsx
+++ b/website-beta/src/index.tsx
@@ -86,9 +86,32 @@ async function scheduled(_controller: any, env?: any, _ctx?: any) {
       "~/src/lib/statusCache"
     );
     const cache = await getStatusCache(env);
-    const cacheMinutes = cache.cacheMinutes || 1;
+    const cacheMinutes = cache.cacheMinutes || 3;
+    // Determine cron interval minutes once: prefer previously detected value,
+    // otherwise estimate from the previous cache timestamp if available.
+    let cronIntervalMinutes: number | null = cache.cronIntervalMinutes ?? null;
+    if (!cronIntervalMinutes && cache.ts && cache.ts > 0) {
+      const estimated = Math.max(1, Math.round((Date.now() - cache.ts) / 60000));
+      // Accept estimation only if reasonable (<= 60 minutes)
+      if (estimated > 0 && estimated <= 60) cronIntervalMinutes = estimated;
+    }
+
     const monitors = await checkStatus();
-    await setStatusCache(monitors, Date.now(), cacheMinutes, env);
+    // Compute explicit nextGenTs aligned to the detected/estimated interval so
+    // clients can rely on an exact timestamp for their countdowns.
+    let nextGenTs: number | null = null;
+    const now = Date.now();
+    const stepMinutes = cronIntervalMinutes ?? cacheMinutes;
+    if (stepMinutes && stepMinutes > 0) {
+      const minuteIndex = Math.floor(now / 60000);
+      const nextMultiple = Math.floor(minuteIndex / stepMinutes) * stepMinutes + stepMinutes;
+      nextGenTs = nextMultiple * 60000;
+      if (nextGenTs <= now) nextGenTs += stepMinutes * 60 * 1000;
+    }
+
+    // Pass both nextGenTs and cronIntervalMinutes so KV stores exact timestamp
+    // and the detected interval for future alignment.
+    await setStatusCache(monitors, Date.now(), cacheMinutes, env, nextGenTs, cronIntervalMinutes);
     console.log("scheduled: refreshed status cache");
   } catch (e) {
     console.error("scheduled handler failed", e);


### PR DESCRIPTION
Updated cache logic to prefer a detected Cloudflare Cron interval for cache alignment and TTL calculations, falling back to cacheMinutes only when necessary. This ensures more accurate countdowns and cache refreshes for clients, and stores both nextGenTs and cronIntervalMinutes in the cache for future alignment.
