### PR TITLE
feat: Switch project license to Apache-2.0

### DIFF
--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,0 +1,13 @@
+Copyright 2026 ScratchCore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/apps/backend/LICENCE.txt
+++ b/apps/backend/LICENCE.txt
@@ -1,0 +1,13 @@
+Copyright 2026 ScratchCore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/apps/frontend/LICENCE.txt
+++ b/apps/frontend/LICENCE.txt
@@ -1,0 +1,13 @@
+Copyright 2026 ScratchCore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "packageManager": "pnpm@10.28.2",
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",

--- a/packages/configs/LICENCE.txt
+++ b/packages/configs/LICENCE.txt
@@ -1,0 +1,13 @@
+Copyright 2026 ScratchCore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -27,7 +27,7 @@
     "scratch-status-monitor"
   ],
   "author": "scratchcore",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "packageManager": "pnpm@10.28.2",
   "devDependencies": {
     "@biomejs/biome": "2.3.14",

--- a/packages/tanstack-plugin-headcontroller/LICENCE.txt
+++ b/packages/tanstack-plugin-headcontroller/LICENCE.txt
@@ -1,0 +1,13 @@
+Copyright 2026 ScratchCore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/tanstack-plugin-headcontroller/package.json
+++ b/packages/tanstack-plugin-headcontroller/package.json
@@ -30,7 +30,7 @@
     "react"
   ],
   "author": "scratchcore",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "packageManager": "pnpm@10.28.2",
   "dependencies": {
     "@tanstack/react-router": "^1.159.5",

--- a/packages/types/LICENCE.txt
+++ b/packages/types/LICENCE.txt
@@ -1,0 +1,13 @@
+Copyright 2026 ScratchCore
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,7 +27,7 @@
     "scratch-status-monitor"
   ],
   "author": "scratchcore",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "packageManager": "pnpm@10.28.2",
   "devDependencies": {
     "@biomejs/biome": "2.3.14",


### PR DESCRIPTION
Standardize licensing across the repo by adding Apache-2.0 LICENSE.txt files (root, apps/backend, apps/frontend, packages/configs, packages/tanstack-plugin-headcontroller, packages/types) and update package.json license fields (root, packages/configs, packages/tanstack-plugin-headcontroller, packages/types) from ISC/MIT to Apache-2.0.
