### PR TITLE
fix: Skip /s in locale middleware; fix redirect

### DIFF
--- a/apps/frontend/src/middleware/locale.ts
+++ b/apps/frontend/src/middleware/locale.ts
@@ -16,6 +16,11 @@ export const localeMiddleware = createMiddleware().server(async ({ next, request
 
   console.log("[localeMiddleware] リクエストパス:", pathname);
 
+  if (pathname === "/s" || pathname.startsWith("/s/")) {
+    console.log("[localeMiddleware] /s ルートは処理対象外");
+    return next();
+  }
+
   // パスから locale を抽出 (例: /fr/page → fr, /ja/page → ja)
   const pathSegments = pathname.split("/").filter(Boolean);
   const locale = pathSegments[0];

--- a/apps/frontend/src/routes/s/$.tsx
+++ b/apps/frontend/src/routes/s/$.tsx
@@ -11,8 +11,9 @@ export const Route = createFileRoute("/s/$")({
     if (!mapping) {
       // マッピングが見つからない場合、ホームへリダイレクト
       console.warn(`Short URL not found: ${pathKey}`);
+      const redirectPath = `/${pathKey}`;
       throw redirect({
-        to: "/",
+        to: redirectPath,
         replace: true,
       });
     }


### PR DESCRIPTION
Skip processing in locale middleware for /s and /s/* routes so short-url routes are handled by their own route. Adjust short URL handler to redirect missing mappings to `/${pathKey}` instead of `/`, and add debug logging for clearer behavior.
