### PR TITLE
docs: Add About and Funding content pages

### DIFF
--- a/apps/frontend/content/about/en.mdx
+++ b/apps/frontend/content/about/en.mdx
@@ -1,0 +1,120 @@
+---
+title: Overview
+summary: A status page system that monitors Scratch service uptime in real time and communicates it clearly to users
+updated_at: 2026-02-16
+---
+
+import {
+  RiTargetLine,
+  RiWirelessChargingLine,
+  RiToolsLine,
+  RiBarChartLine,
+  RiSpaceShip2Line,
+  RiShakeHandsLine,
+  RiGithubFill,
+} from "@remixicon/react";
+
+# Scratch Status Monitor (SSM)
+
+Scratch Status Monitor (SSM) is a status page system designed to monitor the operational state of various [Scratch](https://scratch.mit.edu) features and present that information to users in a clear, understandable way.
+
+<Callout variant="warning" title="Notice">
+  This project is not affiliated with [scratchstats.com](https://scratchstats.com).
+</Callout>
+
+## <RiTargetLine className="inline-block pb-1" size={30} /> Purpose
+
+People who use Scratch regularly often run into issues like:
+
+- Cloud variables are unavailable
+- Trends are not updating
+- Projects are not loading
+- Comments cannot be posted
+
+When these issues occur, the biggest challenge is **not knowing where the cause is**:
+
+- Is there a problem with my local environment?
+- Is there a problem with Scratch's servers?
+- Is this a temporary outage or a longer-term issue?
+
+To address these inconveniences, SSM **visualizes Scratch service status in real time**.
+
+## <RiWirelessChargingLine className="inline-block pb-1" size={30} /> Key Features
+
+### Real-time Monitoring
+
+- Periodic checks of Scratch API endpoints
+- Automatic refresh every 5 minutes
+- Response time and error rate tracking
+
+### Uptime History Recording
+
+- Stores past service status as time-series data
+- Enables impact analysis during incidents
+- Long-term trend visibility via graphs
+
+### Clear Status Indicators
+
+- **Operational**: Everything is working normally
+- **Degraded**: Minor issues detected in some areas
+- **Outage**: Major service issues are occurring
+
+## <RiToolsLine className="inline-block pb-1" size={30} /> Tech Stack
+
+### Frontend
+
+- **TanStack Router** - File-based routing
+- **React** - UI components
+- **TanStack Query** - Server-state management
+- **shadcn/ui** - UI component library
+- **Tailwind CSS** - Styling
+
+### Backend
+
+- **Hono** - Lightweight web framework
+- **oRPC** - Type-safe RPC communication
+- **Cloudflare Workers** - Edge computing
+- **Supabase** - Database
+
+### Infrastructure
+
+- **Cloudflare CDN** - Global content delivery
+- **Cloudflare Cron Triggers** - Scheduled monitoring tasks
+- **GitHub Actions** - CI/CD
+
+## <RiBarChartLine className="inline-block pb-1" size={30} /> Monitored Services
+
+Currently, the following Scratch services are monitored:
+
+- Project API
+- Cloud Variables Server
+- Trends API
+- User Profile API
+- Comment system
+- Other critical endpoints
+
+## <RiSpaceShip2Line className="inline-block pb-1" size={30} /> Roadmap
+
+- More detailed error categorization
+- Expanded multilingual support
+- Alert notifications (Discord, email, etc.)
+- Additional performance metrics
+- Custom monitoring settings
+
+## <RiShakeHandsLine className="inline-block pb-1" size={30} /> Contributing
+
+This project is open source. Bug reports, feature suggestions, and pull requests are welcome.
+
+<div className="my-4">
+
+<a
+  className="inline-flex items-center gap-2 rounded-md border border-input h-9 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+  href="/s/gh/repo"
+  target="_blank"
+  rel="noopener noreferrer"
+>
+  <RiGithubFill size={16} />
+  <span>GitHub Repository</span>
+</a>
+
+</div>

--- a/apps/frontend/content/funding/en.mdx
+++ b/apps/frontend/content/funding/en.mdx
@@ -1,0 +1,97 @@
+---
+title: Operations and Support
+summary: About the operational status of Scratch Status Monitor (SSM) and why we are asking for financial support
+updated_at: 2026-02-16
+---
+
+# Operations and Support
+
+Scratch Status Monitor (SSM) is an unofficial, community-based project aimed at continuously monitoring the operational status of Scratch-related services and making outages or slowdowns visible.
+
+This page explains SSM's current operational status and why we are asking for financial support.
+
+## Project Operations Structure
+
+- Operating organization: ScratchCore
+- Project: Scratch Status Monitor (SSM)
+- Operator: Individual (student)
+
+SSM does not receive investment or grants from specific companies or organizations, and is developed and maintained as a **non-profit project run by an individual**.
+
+## Current Operational Status
+
+During pre-release test operations, SSM reached Cloudflare limits due to higher-than-expected traffic and request volume.
+
+To address this issue and provide stable service, we have upgraded to a **paid Cloudflare plan**.
+
+### Main Ongoing Costs
+
+- Cloudflare (paid plan)
+- Monitoring and logging infrastructure costs
+- Additional costs for future scaling
+
+## Why We Are Asking for Support
+
+The operator is a student and does not have a stable income.
+Current operating costs are being covered **from part-time job income**.
+
+At the same time, we need to balance:
+
+- Savings for future education and living expenses
+- Ongoing project operations
+- Service stability and reliability
+
+Balancing all of these through personal funding alone has limits.
+
+For this reason, we are asking for **financial support within a comfortable range**.
+
+## About Supporting
+
+All SSM features are available **even if you do not provide support**.
+Support is entirely optional and never mandatory.
+
+Funds received through support are used only for the following purposes:
+
+- Covering infrastructure costs
+- Stable service operations
+- Future feature improvements and maintenance
+
+You can currently support us through the following method:
+
+<a href="/s/funding/bmc" target="_blank" rel="noopener noreferrer" className='inline-flex' data-not-external-icon>
+<img src="/wp-content/brand/bmc/yellow-button.png" alt="Buy Me a Coffee" className='h-10'/>
+</a>
+
+## Cost Overview
+
+<Callout>
+Actual expenses vary depending on access volume and monitoring frequency.
+</Callout>
+
+Operating SSM involves ongoing costs such as the following.
+
+### Fixed Costs
+
+- **Domain cost**  
+  Approx. **$8 / year**
+
+### Variable Costs
+
+- **Backend and frontend related services (Cloudflare, etc.)**  
+  Approx. **$5+ / month**  
+  * Depends on usage and traffic volume
+
+These costs are used directly to maintain stable service operations and monitoring accuracy.
+
+## Relationship with the Terms of Service
+
+This page is intended to explain SSM's operational status and the background behind support requests.
+
+For service usage conditions, disclaimers, and legal handling, the [Terms of Service](/policies/terms) take precedence.
+
+## Final Note
+
+SSM aims to create an environment where anyone can accurately understand Scratch's current status.
+If you find value in this project, support in any form would be a great encouragement.
+
+Thank you for your continued support of Scratch Status Monitor.


### PR DESCRIPTION
Add two new English MDX content pages: apps/frontend/content/about/en.mdx (project overview for Scratch Status Monitor with purpose, features, tech stack, monitored services, roadmap, and a GitHub link) and apps/frontend/content/funding/en.mdx (operations and support details including operational status, cost breakdown, and payment/support instructions). Both files include frontmatter metadata (title, summary, updated_at) and site-specific UI imports/callouts.
