### PR TITLE
chore: Add date CLI and small layout tweaks

### DIFF
--- a/.scripts/date.ts
+++ b/.scripts/date.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { input } from "@inquirer/prompts";
+
+const inputLocale = await input({ message: 'Enter locale (e.g. "ja-JP")', default: "ja-JP" });
+const outputLocale = new Intl.Locale(inputLocale);
+const inputTimeZone = await input({
+  message: 'Enter time zone (e.g. "Asia/Tokyo")',
+  default: "Asia/Tokyo",
+});
+const inputDate = await input({
+  message: "Enter date",
+  default: new Date().toLocaleString(inputLocale),
+});
+
+const output = new Intl.DateTimeFormat(outputLocale, {
+  timeZone: inputTimeZone,
+}).format(new Date(inputDate));
+
+const date = new Date(output);
+const ISODate = date.toISOString();
+
+console.log(`
+Input Locale: ${inputLocale}
+Input Time Zone: ${inputTimeZone}
+Input Date: ${inputDate}
+Output Date: ${output}
+ISO Date: ${ISODate}
+`);

--- a/apps/frontend/src/components/markdown/layout.tsx
+++ b/apps/frontend/src/components/markdown/layout.tsx
@@ -11,7 +11,7 @@ export interface ArticleLayoutProps {
 }
 export function ArticleLayout(props: ArticleLayoutProps) {
   return (
-    <div className="mx-auto max-w-3xl p-4 lg:py-8">
+    <div className="max-w-3xl p-4 lg:py-8 mx-auto">
       <HeaderNotice isDefault={props.isDefault} locale={props.locale} />
       <UpdatedAtContent updated_at={props.updated_at} locale={props.locale} />
       <article className="typography w-full max-w-full!">

--- a/apps/frontend/src/routes/$locale/404.tsx
+++ b/apps/frontend/src/routes/$locale/404.tsx
@@ -25,7 +25,7 @@ export function NotFoundComponent() {
   const { backHome, lostMessage, subtitle, title } = useIntlayer("not-found");
 
   return (
-    <div className="max-w-3xl mx-auto flex flex-col items-center justify-center px-4 text-center pt-20">
+    <div className="flex flex-col items-center justify-center text-center max-w-3xl px-4 pt-20 mx-auto">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
         <div className="absolute top-1/4 left-1/4 h-64 w-64 animate-pulse rounded-full bg-primary/30 blur-3xl" />
         <div className="absolute right-1/4 bottom-1/4 h-96 w-96 animate-pulse rounded-full bg-secondary/30 blur-3xl" />

--- a/apps/frontend/src/routes/$locale/index.tsx
+++ b/apps/frontend/src/routes/$locale/index.tsx
@@ -148,7 +148,7 @@ function App() {
       nextRefreshAt={nextRefreshAt}
       refreshIntervalMs={refreshIntervalMs}
     >
-      <div className="max-w-3xl mx-auto p-4 lg:py-8">
+      <div className="max-w-3xl p-4 lg:py-8 mx-auto">
         {/* エラーアラート */}
         {error && (
           <Callout variant="error" title="重要なお知らせ" className="my-5">

--- a/apps/frontend/src/routes/$locale/policies/index.tsx
+++ b/apps/frontend/src/routes/$locale/policies/index.tsx
@@ -48,7 +48,7 @@ export const Route = createFileRoute("/$locale/policies/")({
 function RouteComponent() {
   const loaderData = Route.useLoaderData();
   return (
-    <div className="mx-auto max-w-3xl p-4 lg:py-8">
+    <div className="max-w-3xl p-4 lg:py-8 mx-auto">
       <h1 className="text-3xl font-bold mb-6">Policies</h1>
       <ItemGroup className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {loaderData.content.map((policy, index) => (

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "scratch-status-monitor",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "taze": "taze -r",
@@ -12,7 +12,8 @@
     "format:check": "biome format .",
     "check": "biome check .",
     "check:fix": "biome check --write .",
-    "gen-icon:magick": "tsx ./.scripts/gen-icon-magick.ts"
+    "gen-icon:magick": "tsx ./.scripts/gen-icon-magick.ts",
+    "date": "tsx ./.scripts/date.ts"
   },
   "keywords": [],
   "author": "",
@@ -20,6 +21,7 @@
   "packageManager": "pnpm@10.29.3",
   "devDependencies": {
     "@biomejs/biome": "^2.3.15",
+    "@inquirer/prompts": "^8.2.1",
     "@types/node": "^25.2.3",
     "commander": "^14.0.3",
     "inquirer": "^13.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.3.15
         version: 2.3.15
+      '@inquirer/prompts':
+        specifier: ^8.2.1
+        version: 8.2.1(@types/node@25.2.3)
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3


### PR DESCRIPTION
Add an interactive date utility at .scripts/date.ts that prompts for locale, time zone, and date, formats the date and prints an ISO timestamp. Update package.json to set type to module, add a "date" script, and add @inquirer/prompts as a devDependency. Make minor className reordering tweaks (moving mx-auto) in several frontend components for consistency. Update lockfile.
