### PR TITLE
feat: Update transparency site URL in Astro config

### DIFF
--- a/apps/transparency/astro.config.ts
+++ b/apps/transparency/astro.config.ts
@@ -2,8 +2,7 @@ import { defineConfig } from "astro/config";
 import UnoCSS from "unocss/astro";
 
 export default defineConfig({
-  site: "https://scratchcore.github.io",
-  base: "/scratch-status-monitor",
+  site: "https://transparency.ssm.scra.cc",
   integrations: [
     UnoCSS({
       injectReset: true,


### PR DESCRIPTION
Change the site setting to https://transparency.ssm.scra.cc and remove the custom base path (/scratch-status-monitor) in apps/transparency/astro.config.ts so the transparency app uses the new domain and default base.
