### PR TITLE
feat: Add Transparency link and short URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ https://ssm.scra.cc
 - About: https://ssm.scra.cc/about
 - Policies: https://ssm.scra.cc/policies
 - Support: https://ssm.scra.cc/funding
+- Transparency: https://transparency.ssm.scra.cc
 
 ## Repository Purpose
 

--- a/apps/frontend/src/components/footer.tsx
+++ b/apps/frontend/src/components/footer.tsx
@@ -45,6 +45,7 @@ export function Footer() {
       links: [
         { name: t.links.team, to: "/team" },
         { name: t.links.funding, to: "/funding" },
+        { name: t.links.transparency, href: "/s/transparency" },
         {
           name: t.links.issues,
           href: "/s/gh/issues",

--- a/apps/frontend/src/content/footer.content.ts
+++ b/apps/frontend/src/content/footer.content.ts
@@ -66,6 +66,12 @@ const footerContent = {
         de: "Finanzierung",
         fr: "Financement",
       }),
+      transparency: t({
+        ja: "透明性",
+        en: "Transparency",
+        de: "Transparenz",
+        fr: "Transparence",
+      }),
       issues: t({
         ja: "問題",
         en: "Issues",

--- a/packages/configs/src/short-urls.ts
+++ b/packages/configs/src/short-urls.ts
@@ -9,6 +9,10 @@ export const shortUrls: ssmrcType.shortUrl[] = [
     url: "https://docs.google.com/forms/d/e/1FAIpQLSexvsgzQ6FDh-402RtAFybh1rFwJerG1AOMcjk_DLIVxeTS4w/viewform",
   },
   {
+    key: "transparency",
+    url: "https://transparency.ssm.scra.cc",
+  },
+  {
     key: "funding",
     url: "/funding/bmc",
   },


### PR DESCRIPTION
Expose the new Transparency page across the project: add a Transparency link to the README, include a footer link (href /s/transparency) in the frontend, add translations for the label (ja/en/de/fr) in footer.content.ts, and register a short URL key `transparency` pointing to https://transparency.ssm.scra.cc in the configs so the short route resolves.
