### PR TITLE
feat: Skip unchanged deploys; add manual force run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,14 @@ on:
   # `main`ブランチにプッシュするたびにワークフローをトリガーします。
   # 別のブランチを使用している場合は、`main`をそのブランチ名に置き換えてください。
   push:
-    branches: [ main ]
+    branches: [main]
   # GitHub上のActionsタブからこのワークフローを手動で実行できます。
   workflow_dispatch:
+    inputs:
+      force_run:
+        description: "Force run even if no changes are detected"
+        required: false
+        default: "false"
 
 # このジョブがリポジトリをクローンし、ページデプロイメントを作成することを許可します。
 permissions:
@@ -15,6 +20,7 @@ permissions:
   id-token: write
 
 env:
+  DATA_PATH: "./data"
   BUILD_PATH: "./apps/transparency"
 
 jobs:
@@ -23,7 +29,21 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v5
+
+      - name: Check for changes
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          git fetch origin --depth=1
+          BASE="${{ github.base_ref }}"
+          [ -z "$BASE" ] && BASE="origin/${{ github.ref_name }}"
+          git diff --quiet "$BASE...HEAD" -- ${{ env.BUILD_PATH }} ${{ env.DATA_PATH }} && echo "skip=true" >> $GITHUB_ENV || true
+
+      - name: Override skip with manual flag
+        if: github.event_name == 'workflow_dispatch' && inputs.force_run == 'true'
+        run: echo "skip=false" >> $GITHUB_ENV
+
       - name: Install, build, and upload your site
+        if: env.skip != 'true'
         uses: withastro/action@v5
         with:
           path: ${{ env.BUILD_PATH }} # リポジトリ内のAstroプロジェクトのルート位置です。（オプション）
@@ -31,7 +51,7 @@ jobs:
           package-manager: pnpm@latest # 依存関係のインストールとサイトのビルドに使用するNodeパッケージマネージャーです。ロックファイルに基づいて自動検出されます。（オプション）
           # build-cmd: pnpm run build # サイトをビルドするためのコマンドです。デフォルトでパッケージのbuildスクリプトを実行します。（オプション）
         # env:
-          # PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # 変数の値にはシングルクォートを使用してください。（オプション）
+        # PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # 変数の値にはシングルクォートを使用してください。（オプション）
 
   deploy:
     needs: build


### PR DESCRIPTION
Update .github/workflows/deploy.yml to avoid running site builds when neither the build path nor data path changed. Adds a DATA_PATH env and a git-based change detection step that sets an env flag (skip) when no relevant changes are found. Introduces a workflow_dispatch input (force_run) to allow manually overriding the skip behavior. Also includes minor formatting/whitespace fixes and ensures the deploy step runs conditionally based on the skip flag.
