### PR TITLE
fix: Add build 'skip' output and conditional deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ env:
 
 jobs:
   build:
+    outputs:
+      skip: ${{ env.skip }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
@@ -54,6 +56,7 @@ jobs:
         # PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # 変数の値にはシングルクォートを使用してください。（オプション）
 
   deploy:
+    if: needs.build.outputs.skip != 'true'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
Expose a build job output named `skip` (mapped from `env.skip`) and make the `deploy` job conditional by adding `if: needs.build.outputs.skip != 'true'`. This allows the workflow to opt out of deployment when the build job sets `skip=true`.
