### PR TITLE
chore: Increase page size for fetchAllHistories

### DIFF
--- a/apps/frontend/src/lib/status-page/server.ts
+++ b/apps/frontend/src/lib/status-page/server.ts
@@ -128,7 +128,7 @@ export const fetchHistories = async (params?: {
  * すべての履歴データを取得（hasMore が false になるまで繰り返し取得）
  */
 export const fetchAllHistories = async (): Promise<StatusPageLoaderData> => {
-  const PAGE_SIZE = 100;
+  const PAGE_SIZE = 1000;
   let offset = 0;
   const historiesMap = new Map<string, StatusPageLoaderData["histories"][number]>();
   let hasMore = true;


### PR DESCRIPTION
Bump PAGE_SIZE from 100 to 1000 in fetchAllHistories to reduce the number of paginated requests when loading all history records. This should improve retrieval performance by fetching larger batches, though it may increase memory usage during aggregation.
