### PR TITLE
feat: Ignore .env*.local and update Vercel scripts

### DIFF
--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -19,3 +19,4 @@ todos.json
 
 public/sitemap.xml
 .vercel
+.env*.local

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -13,9 +13,9 @@
     "check": "biome check",
     "v:dev": "nlx vercel dev",
     "v:build": "nlx vercel build",
-    "v:dep:prev": "nr v:build && nlx vercel deploy --prebuilt",
+    "v:dep:prev": "nlx vercel build --target preview && nlx vercel deploy --prebuilt",
     "o:v:dep:prev": "nlx vercel deploy --prebuilt",
-    "v:dep:prod": "nr v:build && nlx vercel deploy --prebuilt --prod",
+    "v:dep:prod": "nlx vercel build --target production && nlx vercel deploy --prebuilt --prod",
     "o:v:dep:prod": "nlx vercel deploy --prebuilt --prod",
     "machine-translate": "inlang machine translate --project project.inlang"
   },


### PR DESCRIPTION
Add .env*.local to the frontend .gitignore to avoid committing local env variants. Update package.json deploy scripts to run `nlx vercel build --target <preview|production>` before `nlx vercel deploy --prebuilt`, replacing the previous `nr v:build && ...` pattern to ensure builds use the correct Vercel target for preview and production deployments.
