### PR TITLE
Add Cloudflare expense (2026-04-03)

### DIFF
--- a/data/expenses/2026-04-03.yaml
+++ b/data/expenses/2026-04-03.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=../../apps/transparency/.astro/collections/expenses.schema.json
+payment_at: 2026-04-02T15:00:00.000Z
+from: "Cloudflare, Inc."
+standard: "JAPAN"
+tax_percent: 10.0
+paid:
+  currency: "JPY"
+  amount: 914.00
+  by: "Toa Kiryu"
+items:
+  - name: "Workers Paid"
+    price: 5.00
+    quantity: 1
+    period:
+      start_at: 2026-04-02T15:00:00.000Z
+      end_at: 2026-05-01T15:00:00.000Z


### PR DESCRIPTION
This pull request adds a new expense record for a Cloudflare service payment in April 2026. The entry includes details such as the payment date, payer, tax information, payment amount, and service period.

Expense tracking:

* Added a new file `data/expenses/2026-04-03.yaml` to record a JPY 914.00 payment to "Cloudflare, Inc." for a "Workers Paid" service, including tax details and service period.